### PR TITLE
Fix JSDoc types

### DIFF
--- a/src/Back/Helper/Mime.js
+++ b/src/Back/Helper/Mime.js
@@ -7,7 +7,7 @@ export default class Fl32_Web_Back_Helper_Mime {
         /**
          * Mapping from file extension to MIME type.
          * Keys must start with a dot, e.g. '.html'.
-         * @type {Object<string, string>}
+         * @type {{[key: string]: string}}
          */
         const _types = Object.freeze({
             '.aac': 'audio/aac',

--- a/src/Back/Helper/Respond.js
+++ b/src/Back/Helper/Respond.js
@@ -35,10 +35,10 @@ export default class Fl32_Web_Back_Helper_Respond {
         /**
          * Sends an HTTP response with a given status code.
          *
-         * @param {Object} params
+         * @param {object} params
          * @param {module:http.ServerResponse|module:http2.Http2ServerResponse} params.res - HTTP response object.
-         * @param {Object<string, string>} [params.headers={}] - Custom headers.
-         * @param {string|Object} [params.body=''] - Response body.
+         * @param {{[key: string]: string}} [params.headers={}] - Custom headers.
+         * @param {string|object} [params.body=''] - Response body.
          * @param {number} status - HTTP status code.
          * @returns {boolean} - `true` if response was sent, `false` if headers were already sent.
          */


### PR DESCRIPTION
## Summary
- correct JSDoc type for Mime helper map
- fix JSDoc types in Respond helper

## Testing
- `npm run eslint`
- `npm run test:unit`
- `npm run test:accept` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f7b55df0832d9839e1e2fb74bcda