### PR TITLE
Implement server stop

### DIFF
--- a/src/Back/Server.js
+++ b/src/Back/Server.js
@@ -78,7 +78,15 @@ export default class Fl32_Web_Back_Server {
          * @returns {Promise<void>}
          */
         this.stop = async function () {
-            console.log(`The server is stopping...`);
+            if (_instance) {
+                await new Promise((resolve, reject) => {
+                    _instance.close(err => err ? reject(err) : resolve());
+                });
+                logger.info('Server stopped');
+                _instance = undefined;
+            } else {
+                logger.warn('Server is not running');
+            }
         };
     }
 }

--- a/test/unit/Back/Server.test.mjs
+++ b/test/unit/Back/Server.test.mjs
@@ -14,6 +14,7 @@ describe('Fl32_Web_Back_Server (mocked)', () => {
         createServer: () => ({
             listen: () => { log.push('http.listen'); },
             on: () => { log.push('http.on'); },
+            close: (cb) => { log.push('http.close'); cb && cb(); },
         }),
     };
 
@@ -21,10 +22,12 @@ describe('Fl32_Web_Back_Server (mocked)', () => {
         createServer: () => ({
             listen: () => { log.push('http2.listen'); },
             on: () => { log.push('http2.on'); },
+            close: (cb) => { log.push('http2.close'); cb && cb(); },
         }),
         createSecureServer: (tlsOpts) => ({
             listen: () => { log.push('http2s.listen'); },
             on: () => { log.push('http2s.on'); },
+            close: (cb) => { log.push('http2s.close'); cb && cb(); },
         })
     };
 
@@ -95,5 +98,15 @@ describe('Fl32_Web_Back_Server (mocked)', () => {
             /not supported/
         );
         assert.deepStrictEqual(log.at(-1), ['error', 'Unsupported server type: ftp']);
+    });
+
+    it('should stop the server', async () => {
+        const server = await container.get('Fl32_Web_Back_Server$');
+        await server.start();
+        await server.stop();
+        assert.deepStrictEqual(log.slice(-2), [
+            'http.close',
+            ['info', 'Server stopped'],
+        ]);
     });
 });


### PR DESCRIPTION
## Summary
- implement `stop()` logic to close the running server
- extend mocks to include `close()`
- test stopping the server

## Testing
- `npm run eslint` *(fails: eslint not installed)*
- `npm run test:unit` *(fails: _mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848fc54497c832dbd2171a382825b70