### PR TITLE
Fix unit test runner path

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "eslint": "./node_modules/.bin/eslint ./src/",
     "test:accept": "node --test test/accept",
-    "test:unit": "node --test test/unit"
+    "test:unit": "node --test ./test/unit"
   },
   "dependencies": {
     "@teqfw/di": ">=0.34.0"


### PR DESCRIPTION
## Summary
- ensure node:test runner uses a relative path in `test:unit` script

## Testing
- `npm run test:unit --silent`

------
https://chatgpt.com/codex/tasks/task_e_684906b83ba0832d81f29638aa3b7b5a