### PR TITLE
Add express/fastify integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,30 @@ This will start an HTTPS server on port `3443` with:
 
 ---
 
+### Using with Express or Fastify
+
+The dispatcher can be connected to external web frameworks instead of the built-in server.
+
+```js
+// Express
+const app = Express();
+app.use(async (req, res) => {
+    await dispatcher.onEventRequest(req, res);
+});
+app.listen(3000);
+
+// Fastify
+const fastify = Fastify();
+fastify.all('*', async (request, reply) => {
+    const req = request.raw;
+    const res = reply.raw;
+    await dispatcher.onEventRequest(req, res);
+});
+await fastify.listen({port: 3000});
+```
+
+---
+
 ## Installation
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "eslint": "^9.25.0",
-    "eslint-plugin-jsdoc": "^50.6.8"
+    "eslint-plugin-jsdoc": "^50.6.8",
+    "express": "^4.18.2",
+    "fastify": "^4.27.2"
   },
   "engines": {
     "node": ">=20"

--- a/test/accept/ExternalServer.test.mjs
+++ b/test/accept/ExternalServer.test.mjs
@@ -1,0 +1,66 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import {buildTestContainer} from '../unit/common.js';
+import Express from 'express';
+import Fastify from 'fastify';
+
+async function startExpress(port, dispatcher) {
+  const app = Express();
+  app.use(async (req, res) => {
+    await dispatcher.onEventRequest(req, res);
+  });
+  await new Promise((resolve, reject) => {
+    const srv = app.listen(port, err => err ? reject(err) : resolve(srv));
+  });
+  return app;
+}
+
+async function startFastify(port, dispatcher) {
+  const fastify = Fastify();
+  fastify.all('*', async (request, reply) => {
+    const req = request.raw;
+    const res = reply.raw;
+    await dispatcher.onEventRequest(req, res);
+  });
+  await fastify.listen({port});
+  return fastify;
+}
+
+describe('Dispatcher integration with external servers', () => {
+  it('should respond via express', async () => {
+    const container = buildTestContainer();
+    const dispatcher = await container.get('Fl32_Web_Back_Dispatcher$');
+    const port = 3054;
+    const app = await startExpress(port, dispatcher);
+
+    const status = await new Promise((resolve, reject) => {
+      http.get(`http://localhost:${port}`, res => {
+        const {statusCode} = res;
+        res.resume();
+        res.on('end', () => resolve(statusCode));
+      }).on('error', reject);
+    });
+
+    assert.strictEqual(status, 404);
+    await new Promise(resolve => app.close(resolve));
+  });
+
+  it('should respond via fastify', async () => {
+    const container = buildTestContainer();
+    const dispatcher = await container.get('Fl32_Web_Back_Dispatcher$');
+    const port = 3055;
+    const fastify = await startFastify(port, dispatcher);
+
+    const status = await new Promise((resolve, reject) => {
+      http.get(`http://localhost:${port}`, res => {
+        const {statusCode} = res;
+        res.resume();
+        res.on('end', () => resolve(statusCode));
+      }).on('error', reject);
+    });
+
+    assert.strictEqual(status, 404);
+    await fastify.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add express and fastify to devDependencies
- document how to use dispatcher with Express or Fastify
- test dispatcher integration with Express and Fastify
- remove stub express/fastify modules

## Testing
- `npm run test:unit`
- `npm run test:accept` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68499e2a168c832da9c1eabadfc5dd02