### PR TITLE
Implement NPM static handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,20 @@ resolver.addNamespaceRoot('Fl32_Web_', './node_modules/@flancer32/teq-web/src');
 
 // Get and configure built-in handlers
 const logHandler = await container.get('Fl32_Web_Back_Handler_Pre_Log$');
+const npmHandler = await container.get('Fl32_Web_Back_Handler_Npm$');
 const staticHandler = await container.get('Fl32_Web_Back_Handler_Static$');
+await npmHandler.init({
+    allow: {
+        vue: ['dist/vue.global.prod.js'],
+        '@teqfw/di': ['src/Container.js'],
+    }
+});
 await staticHandler.init({rootPath: webRoot});
 
 // Register handlers
 const dispatcher = await container.get('Fl32_Web_Back_Dispatcher$');
 dispatcher.addHandler(logHandler);
+dispatcher.addHandler(npmHandler);
 dispatcher.addHandler(staticHandler);
 
 // Create and start the server
@@ -105,6 +113,7 @@ await server.start({
 This will start an HTTPS server on port `3443` with:
 
 * `Fl32_Web_Back_Handler_Pre_Log` logging each request method and URL;
+* `Fl32_Web_Back_Handler_Npm` serving allowed files from `node_modules`;
 * `Fl32_Web_Back_Handler_Static` serving files from the `/web` folder.
 
 ---

--- a/src/Back/Handler/Npm.js
+++ b/src/Back/Handler/Npm.js
@@ -1,0 +1,142 @@
+/**
+ * Serves whitelisted files from ./node_modules directory.
+ * @implements Fl32_Web_Back_Api_Handler
+ */
+export default class Fl32_Web_Back_Handler_Npm {
+    /* eslint-disable jsdoc/require-param-description,jsdoc/check-param-names */
+    /**
+     * @param {typeof import('node:fs')} fs
+     * @param {typeof import('node:http2')} http2
+     * @param {typeof import('node:path')} path
+     * @param {Fl32_Web_Back_Logger} logger
+     * @param {Fl32_Web_Back_Helper_Mime} helpMime
+     * @param {Fl32_Web_Back_Helper_Respond} respond
+     * @param {Fl32_Web_Back_Dto_Handler_Info} dtoInfo
+     * @param {typeof Fl32_Web_Back_Enum_Stage} STAGE
+     */
+    constructor(
+        {
+            'node:fs': fs,
+            'node:http2': http2,
+            'node:path': path,
+            Fl32_Web_Back_Logger$: logger,
+            Fl32_Web_Back_Helper_Mime$: helpMime,
+            Fl32_Web_Back_Helper_Respond$: respond,
+            Fl32_Web_Back_Dto_Handler_Info$: dtoInfo,
+            Fl32_Web_Back_Enum_Stage$: STAGE,
+        }
+    ) {
+        /* eslint-enable jsdoc/check-param-names */
+        // VARS
+        const {promises: fsp} = fs;
+        const {constants: H2} = http2;
+        const {
+            HTTP2_HEADER_CONTENT_LENGTH,
+            HTTP2_HEADER_CONTENT_TYPE,
+            HTTP2_HEADER_LAST_MODIFIED,
+            HTTP_STATUS_OK,
+        } = H2;
+        const _root = path.resolve('node_modules');
+
+        /** @type {Fl32_Web_Back_Dto_Handler_Info.Dto} */
+        const _info = dtoInfo.create();
+        _info.name = this.constructor.name;
+        _info.stage = STAGE.PROCESS;
+        Object.freeze(_info);
+
+        /** @type {{[key: string]: string[]}} */
+        let _allow = {};
+
+        // MAIN
+        /**
+         * Handles request to serve allowed files from node_modules.
+         *
+         * @param {module:http.IncomingMessage|module:http2.Http2ServerRequest} req
+         * @param {module:http.ServerResponse|module:http2.Http2ServerResponse} res
+         * @returns {Promise<boolean>}
+         */
+        this.handle = async function (req, res) {
+            if (!respond.isWritable(res)) return false;
+
+            const urlPath = decodeURIComponent(req.url.split('?')[0]);
+            const prefix = '/node_modules/';
+            if (!urlPath.startsWith(prefix)) return false;
+
+            const rel = urlPath.slice(prefix.length);
+            if (rel.includes('..') || path.isAbsolute(rel)) {
+                logger.warn(`NPM static access denied: ${rel}`);
+                return false;
+            }
+
+            let pkg; let subPath;
+            for (const key of Object.keys(_allow)) {
+                if (rel === key || rel.startsWith(`${key}/`)) {
+                    pkg = key;
+                    subPath = rel.slice(key.length);
+                    if (subPath.startsWith('/')) subPath = subPath.slice(1);
+                    break;
+                }
+            }
+            if (!pkg) return false;
+
+            const rules = _allow[pkg] || [];
+            let allowed = false;
+            if (rules.includes('.')) {
+                allowed = true;
+            } else {
+                for (const p of rules) {
+                    if (subPath === p || subPath.startsWith(`${p}/`)) {
+                        allowed = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!allowed) {
+                logger.warn(`NPM static access denied: ${rel}`);
+                return false;
+            }
+
+            const fsPath = path.resolve(_root, rel);
+            if (!fsPath.startsWith(_root)) {
+                logger.warn(`NPM static access denied: ${rel}`);
+                return false;
+            }
+
+            let stat;
+            try {
+                stat = await fsp.stat(fsPath);
+            } catch {
+                logger.warn(`NPM static file not found: ${rel}`);
+                return false;
+            }
+            if (!stat.isFile()) {
+                logger.warn(`NPM static file not found: ${rel}`);
+                return false;
+            }
+
+            const stream = fs.createReadStream(fsPath);
+            const ext = path.extname(fsPath).toLowerCase();
+            const headers = {
+                [HTTP2_HEADER_CONTENT_LENGTH]: stat.size,
+                [HTTP2_HEADER_CONTENT_TYPE]: helpMime.getByExt(ext),
+                [HTTP2_HEADER_LAST_MODIFIED]: stat.mtime.toUTCString(),
+            };
+            res.writeHead(HTTP_STATUS_OK, headers);
+            stream.pipe(res);
+            return true;
+        };
+
+        /**
+         * Initialize handler with allow list.
+         * @param {object} params
+         * @param {{[key: string]: string[]}} params.allow
+         */
+        this.init = async function ({allow}) {
+            _allow = allow || {};
+        };
+
+        /** @returns {Fl32_Web_Back_Dto_Handler_Info.Dto} */
+        this.getRegistrationInfo = () => _info;
+    }
+}

--- a/test/dev/app/Plugin/Start.js
+++ b/test/dev/app/Plugin/Start.js
@@ -4,6 +4,7 @@ export default class App_Plugin_Start {
      * @param {typeof import('node:url')} url
      * @param {Fl32_Web_Back_Dispatcher} dispatcher
      * @param {Fl32_Web_Back_Handler_Pre_Log} hndlRequestLog
+     * @param {Fl32_Web_Back_Handler_Npm} hndlNpm
      * @param {Fl32_Web_Back_Handler_Static} hndlStatic
      */
     constructor(
@@ -12,6 +13,7 @@ export default class App_Plugin_Start {
             'node:url': url,
             Fl32_Web_Back_Dispatcher$: dispatcher,
             Fl32_Web_Back_Handler_Pre_Log$: hndlRequestLog,
+            Fl32_Web_Back_Handler_Npm$: hndlNpm,
             Fl32_Web_Back_Handler_Static$: hndlStatic,
         }
     ) {
@@ -29,9 +31,11 @@ export default class App_Plugin_Start {
 
         return async function () {
             // Set up handlers
+            await hndlNpm.init({allow: {'@teqfw/di': ['src/Container.js']}});
             await hndlStatic.init({rootPath: webRoot});
             // Register handlers
             dispatcher.addHandler(hndlRequestLog);
+            dispatcher.addHandler(hndlNpm);
             dispatcher.addHandler(hndlStatic);
         };
     }

--- a/test/unit/Back/Handler/Npm.test.mjs
+++ b/test/unit/Back/Handler/Npm.test.mjs
@@ -1,0 +1,69 @@
+import {describe, it, beforeEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {Writable} from 'node:stream';
+import {buildTestContainer} from '../../common.js';
+
+class MockRes extends Writable {
+    constructor() {
+        super();
+        this.data = Buffer.alloc(0);
+        this.statusCode = undefined;
+        this.headers = undefined;
+        this._headersSent = false;
+        this._ended = false;
+    }
+    get headersSent() { return this._headersSent; }
+    get writableEnded() { return this._ended; }
+    writeHead(status, headers) {
+        this.statusCode = status;
+        this.headers = headers;
+        this._headersSent = true;
+    }
+    _write(chunk, enc, cb) {
+        this.data = Buffer.concat([this.data, chunk]);
+        cb();
+    }
+    end(chunk) {
+        if (chunk) this.data = Buffer.concat([this.data, Buffer.from(chunk)]);
+        this._ended = true;
+        super.end();
+    }
+}
+
+describe('Fl32_Web_Back_Handler_Npm', () => {
+    let container;
+    const log = [];
+
+    beforeEach(() => {
+        container = buildTestContainer();
+        container.register('Fl32_Web_Back_Logger$', {
+            warn: (...args) => log.push(['warn', ...args]),
+            exception: (...args) => log.push(['exception', ...args]),
+        });
+        log.length = 0;
+    });
+
+    it('should serve allowed file', async () => {
+        const handler = await container.get('Fl32_Web_Back_Handler_Npm$');
+        await handler.init({allow: {'@teqfw/di': ['package.json']}});
+        const req = {url: '/node_modules/@teqfw/di/package.json'};
+        const res = new MockRes();
+        const ok = await handler.handle(req, res);
+        await new Promise(resolve => res.on('finish', resolve));
+        assert.strictEqual(ok, true);
+        assert.strictEqual(res.statusCode, 200);
+        assert.match(res.data.toString(), /@teqfw\/di/);
+        assert.strictEqual(log.length, 0);
+    });
+
+    it('should deny disallowed path', async () => {
+        const handler = await container.get('Fl32_Web_Back_Handler_Npm$');
+        await handler.init({allow: {'@teqfw/di': ['package.json']}});
+        const req = {url: '/node_modules/@teqfw/di/secret.js'};
+        const res = new MockRes();
+        const ok = await handler.handle(req, res);
+        assert.strictEqual(ok, false);
+        assert.strictEqual(res.headersSent, false);
+        assert.ok(log[0][0] === 'warn');
+    });
+});


### PR DESCRIPTION
## Summary
- add `Fl32_Web_Back_Handler_Npm` to serve whitelisted files from `node_modules`
- register the handler in dev bootstrap before the static handler
- document usage of the new handler in README
- test new handler logic

## Testing
- `npm run eslint`
- `npm run test:unit`
- `npm run test:accept`

------
https://chatgpt.com/codex/tasks/task_e_685569b2ccf4832da06d766a0e0ea33a