### PR TITLE
Generalize npm file handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ resolver.addNamespaceRoot('Fl32_Web_', './node_modules/@flancer32/teq-web/src');
 
 // Get and configure built-in handlers
 const logHandler = await container.get('Fl32_Web_Back_Handler_Pre_Log$');
-const npmHandler = await container.get('Fl32_Web_Back_Handler_Npm$');
+const sourceHandler = await container.get('Fl32_Web_Back_Handler_Source$');
 const staticHandler = await container.get('Fl32_Web_Back_Handler_Static$');
-await npmHandler.init({
+await sourceHandler.init({
+    root: 'node_modules',
+    prefix: '/node_modules/',
     allow: {
         vue: ['dist/vue.global.prod.js'],
         '@teqfw/di': ['src/Container.js'],
@@ -94,7 +96,7 @@ await staticHandler.init({rootPath: webRoot});
 // Register handlers
 const dispatcher = await container.get('Fl32_Web_Back_Dispatcher$');
 dispatcher.addHandler(logHandler);
-dispatcher.addHandler(npmHandler);
+dispatcher.addHandler(sourceHandler);
 dispatcher.addHandler(staticHandler);
 
 // Create and start the server
@@ -113,7 +115,7 @@ await server.start({
 This will start an HTTPS server on port `3443` with:
 
 * `Fl32_Web_Back_Handler_Pre_Log` logging each request method and URL;
-* `Fl32_Web_Back_Handler_Npm` serving allowed files from `node_modules`;
+* `Fl32_Web_Back_Handler_Source` serving allowed files from `node_modules`;
 * `Fl32_Web_Back_Handler_Static` serving files from the `/web` folder.
 
 ---

--- a/test/accept/Server.test.mjs
+++ b/test/accept/Server.test.mjs
@@ -108,8 +108,10 @@ describe('Fl32_Web_Back_Api_Handler', () => {
   it('should serve allowed NPM file', async () => {
     const container = buildTestContainer();
     const dispatcher = await container.get('Fl32_Web_Back_Dispatcher$');
-    const handler = await container.get('Fl32_Web_Back_Handler_Npm$');
+    const handler = await container.get('Fl32_Web_Back_Handler_Source$');
     await handler.init({
+      root: 'node_modules',
+      prefix: '/node_modules/',
       allow: {
         '@teqfw/di/src': ['.'],
       },

--- a/test/dev/app/Plugin/Start.js
+++ b/test/dev/app/Plugin/Start.js
@@ -4,7 +4,7 @@ export default class App_Plugin_Start {
      * @param {typeof import('node:url')} url
      * @param {Fl32_Web_Back_Dispatcher} dispatcher
      * @param {Fl32_Web_Back_Handler_Pre_Log} hndlRequestLog
-     * @param {Fl32_Web_Back_Handler_Npm} hndlNpm
+     * @param {Fl32_Web_Back_Handler_Source} hndlSource
      * @param {Fl32_Web_Back_Handler_Static} hndlStatic
      */
     constructor(
@@ -13,7 +13,7 @@ export default class App_Plugin_Start {
             'node:url': url,
             Fl32_Web_Back_Dispatcher$: dispatcher,
             Fl32_Web_Back_Handler_Pre_Log$: hndlRequestLog,
-            Fl32_Web_Back_Handler_Npm$: hndlNpm,
+            Fl32_Web_Back_Handler_Source$: hndlSource,
             Fl32_Web_Back_Handler_Static$: hndlStatic,
         }
     ) {
@@ -31,11 +31,11 @@ export default class App_Plugin_Start {
 
         return async function () {
             // Set up handlers
-            await hndlNpm.init({allow: {'@teqfw/di': ['src/Container.js']}});
+            await hndlSource.init({root: 'node_modules', prefix: '/node_modules/', allow: {'@teqfw/di': ['src/Container.js']}});
             await hndlStatic.init({rootPath: webRoot});
             // Register handlers
             dispatcher.addHandler(hndlRequestLog);
-            dispatcher.addHandler(hndlNpm);
+            dispatcher.addHandler(hndlSource);
             dispatcher.addHandler(hndlStatic);
         };
     }

--- a/test/unit/Back/Handler/Source.test.mjs
+++ b/test/unit/Back/Handler/Source.test.mjs
@@ -30,7 +30,7 @@ class MockRes extends Writable {
     }
 }
 
-describe('Fl32_Web_Back_Handler_Npm', () => {
+describe('Fl32_Web_Back_Handler_Source', () => {
     let container;
     const log = [];
 
@@ -44,8 +44,8 @@ describe('Fl32_Web_Back_Handler_Npm', () => {
     });
 
     it('should serve allowed file', async () => {
-        const handler = await container.get('Fl32_Web_Back_Handler_Npm$');
-        await handler.init({allow: {'@teqfw/di': ['package.json']}});
+        const handler = await container.get('Fl32_Web_Back_Handler_Source$');
+        await handler.init({root: 'node_modules', prefix: '/node_modules/', allow: {'@teqfw/di': ['package.json']}});
         const req = {url: '/node_modules/@teqfw/di/package.json'};
         const res = new MockRes();
         const ok = await handler.handle(req, res);
@@ -57,8 +57,8 @@ describe('Fl32_Web_Back_Handler_Npm', () => {
     });
 
     it('should deny disallowed path', async () => {
-        const handler = await container.get('Fl32_Web_Back_Handler_Npm$');
-        await handler.init({allow: {'@teqfw/di': ['package.json']}});
+        const handler = await container.get('Fl32_Web_Back_Handler_Source$');
+        await handler.init({root: 'node_modules', prefix: '/node_modules/', allow: {'@teqfw/di': ['package.json']}});
         const req = {url: '/node_modules/@teqfw/di/secret.js'};
         const res = new MockRes();
         const ok = await handler.handle(req, res);


### PR DESCRIPTION
## Summary
- generalize npm handler to become source handler with pluggable root and prefix
- update tests and dev plugin
- update README to show usage of the new source handler

## Testing
- `npm run eslint`
- `npm run test:unit`
- `npm run test:accept`

------
https://chatgpt.com/codex/tasks/task_e_6858d81d3010832da830c5bcb667b60a