### PR TITLE
Introduce config DTO for source handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ resolver.addNamespaceRoot('Fl32_Web_', './node_modules/@flancer32/teq-web/src');
 const logHandler = await container.get('Fl32_Web_Back_Handler_Pre_Log$');
 const sourceHandler = await container.get('Fl32_Web_Back_Handler_Source$');
 const staticHandler = await container.get('Fl32_Web_Back_Handler_Static$');
-await sourceHandler.init({
+const SourceCfg = await container.get('Fl32_Web_Back_Dto_Handler_Source$');
+const sourceCfg = SourceCfg.create({
     root: 'node_modules',
     prefix: '/node_modules/',
     allow: {
@@ -91,6 +92,7 @@ await sourceHandler.init({
         '@teqfw/di': ['src/Container.js'],
     }
 });
+await sourceHandler.init(sourceCfg);
 await staticHandler.init({rootPath: webRoot});
 
 // Register handlers

--- a/src/Back/Dto/Handler/Source.js
+++ b/src/Back/Dto/Handler/Source.js
@@ -1,0 +1,50 @@
+/**
+ * Factory for Source handler configuration DTO.
+ */
+export default class Fl32_Web_Back_Dto_Handler_Source {
+    /* eslint-disable jsdoc/require-param-description */
+    /**
+     * @param {Fl32_Web_Back_Helper_Cast} cast
+     */
+    constructor(
+        {
+            Fl32_Web_Back_Helper_Cast$: cast,
+        }
+    ) {
+        /* eslint-enable jsdoc/require-param-description */
+        /**
+         * Create validated DTO for Source handler configuration.
+         *
+         * @param {*} data
+         * @returns {Dto}
+         */
+        this.create = function (data) {
+            if (!data || typeof data !== 'object' || Array.isArray(data)) {
+                throw new Error('Configuration object is required');
+            }
+            if (typeof data.root !== 'string' || !data.root) {
+                throw new Error('Invalid value for root');
+            }
+            if (typeof data.prefix !== 'string' || !data.prefix) {
+                throw new Error('Invalid value for prefix');
+            }
+            const res = new Dto();
+            res.root = cast.string(data.root);
+            res.prefix = cast.string(data.prefix);
+            res.allow = cast.stringArrayMap(data.allow);
+            return res;
+        };
+    }
+}
+
+/**
+ * @memberOf Fl32_Web_Back_Dto_Handler_Source
+ */
+class Dto {
+    /** @type {string} */
+    root;
+    /** @type {string} */
+    prefix;
+    /** @type {{[key: string]: string[]}} */
+    allow = {};
+}

--- a/src/Back/Handler/Source.js
+++ b/src/Back/Handler/Source.js
@@ -12,6 +12,7 @@ export default class Fl32_Web_Back_Handler_Source {
      * @param {Fl32_Web_Back_Helper_Mime} helpMime
      * @param {Fl32_Web_Back_Helper_Respond} respond
      * @param {Fl32_Web_Back_Dto_Handler_Info} dtoInfo
+     * @param {Fl32_Web_Back_Dto_Handler_Source} dtoCfg
      * @param {typeof Fl32_Web_Back_Enum_Stage} STAGE
      */
     constructor(
@@ -23,6 +24,7 @@ export default class Fl32_Web_Back_Handler_Source {
             Fl32_Web_Back_Helper_Mime$: helpMime,
             Fl32_Web_Back_Helper_Respond$: respond,
             Fl32_Web_Back_Dto_Handler_Info$: dtoInfo,
+            Fl32_Web_Back_Dto_Handler_Source$: dtoCfg,
             Fl32_Web_Back_Enum_Stage$: STAGE,
         }
     ) {
@@ -160,11 +162,16 @@ export default class Fl32_Web_Back_Handler_Source {
          *   },
          * });
          */
-        this.init = async function ({root = 'node_modules', prefix = '/node_modules/', allow = {}} = {}) {
-            _root = path.resolve(root);
-            _prefix = prefix;
+        /**
+         * @param {Fl32_Web_Back_Dto_Handler_Source.Dto|object} cfg
+         * @returns {Promise<void>}
+         */
+        this.init = async function (cfg = {}) {
+            const dto = dtoCfg.create(cfg);
+            _root = path.resolve(dto.root);
+            _prefix = dto.prefix;
             if (!_prefix.endsWith('/')) _prefix += '/';
-            _allow = allow;
+            _allow = dto.allow;
         };
 
         /** @returns {Fl32_Web_Back_Dto_Handler_Info.Dto} */

--- a/src/Back/Helper/Cast.js
+++ b/src/Back/Helper/Cast.js
@@ -83,4 +83,32 @@ export default class Fl32_Web_Back_Helper_Cast {
         }
         return undefined;
     }
+
+    /**
+     * Cast an object to a map with string keys and array-of-string values.
+     * Throws error on invalid structure or values.
+     *
+     * @param {*} data - Raw input to cast.
+     * @returns {Record<string, string[]>}
+     */
+    stringArrayMap(data) {
+        if (data === undefined) return {};
+        if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+            throw new Error('Invalid value for allow');
+        }
+        const res = {};
+        for (const [key, arr] of Object.entries(data)) {
+            if (!Array.isArray(arr)) throw new Error(`Invalid allow list for ${key}`);
+            const k = this.string(key);
+            if (!k) throw new Error('Invalid allow key');
+            const items = [];
+            for (const item of arr) {
+                const val = this.string(item);
+                if (!val) throw new Error(`Invalid allow list for ${k}`);
+                items.push(val);
+            }
+            res[k] = items;
+        }
+        return res;
+    }
 }

--- a/test/unit/Back/Dto/Handler/Source.test.mjs
+++ b/test/unit/Back/Dto/Handler/Source.test.mjs
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'assert';
+import {buildTestContainer} from '../../../common.js';
+
+test.describe('Fl32_Web_Back_Dto_Handler_Source', () => {
+
+  test('should create valid config DTO with casted fields', async () => {
+    const container = buildTestContainer();
+
+    container.register('Fl32_Web_Back_Helper_Cast$', {
+      string: (data) => typeof data === 'string' ? data : undefined,
+      stringArrayMap: (data) => data,
+    });
+
+    const factory = await container.get('Fl32_Web_Back_Dto_Handler_Source$');
+    const dto = factory.create({
+      root: '/abs/path',
+      prefix: '/src/',
+      allow: { vue: ['dist/vue.global.js'] },
+    });
+
+    assert.strictEqual(dto.root, '/abs/path');
+    assert.strictEqual(dto.prefix, '/src/');
+    assert.deepStrictEqual(dto.allow, { vue: ['dist/vue.global.js'] });
+  });
+
+  test('should throw if required fields are missing or invalid', async () => {
+    const container = buildTestContainer();
+
+    container.register('Fl32_Web_Back_Helper_Cast$', {
+      string: () => undefined,
+      stringArrayMap: () => ({}),
+    });
+
+    const factory = await container.get('Fl32_Web_Back_Dto_Handler_Source$');
+
+    assert.throws(() => {
+      factory.create({});
+    }, /invalid.*root/i);
+
+    assert.throws(() => {
+      factory.create({ root: '/x', prefix: 123 });
+    }, /invalid.*prefix/i);
+  });
+});

--- a/test/unit/Back/Handler/Source.test.mjs
+++ b/test/unit/Back/Handler/Source.test.mjs
@@ -45,7 +45,9 @@ describe('Fl32_Web_Back_Handler_Source', () => {
 
     it('should serve allowed file', async () => {
         const handler = await container.get('Fl32_Web_Back_Handler_Source$');
-        await handler.init({root: 'node_modules', prefix: '/npm/', allow: {'@teqfw/di': ['package.json']}});
+        const cfgFactory = await container.get('Fl32_Web_Back_Dto_Handler_Source$');
+        const cfg = cfgFactory.create({root: 'node_modules', prefix: '/npm/', allow: {'@teqfw/di': ['package.json']}});
+        await handler.init(cfg);
         const req = {url: '/npm/@teqfw/di/package.json'};
         const res = new MockRes();
         const ok = await handler.handle(req, res);
@@ -58,7 +60,9 @@ describe('Fl32_Web_Back_Handler_Source', () => {
 
     it('should deny disallowed path', async () => {
         const handler = await container.get('Fl32_Web_Back_Handler_Source$');
-        await handler.init({root: 'node_modules', prefix: '/npm/', allow: {'@teqfw/di': ['package.json']}});
+        const cfgFactory = await container.get('Fl32_Web_Back_Dto_Handler_Source$');
+        const cfg = cfgFactory.create({root: 'node_modules', prefix: '/npm/', allow: {'@teqfw/di': ['package.json']}});
+        await handler.init(cfg);
         const req = {url: '/npm/@teqfw/di/secret.js'};
         const res = new MockRes();
         const ok = await handler.handle(req, res);
@@ -69,7 +73,9 @@ describe('Fl32_Web_Back_Handler_Source', () => {
 
     it('should serve allowed src file', async () => {
         const handler = await container.get('Fl32_Web_Back_Handler_Source$');
-        await handler.init({root: 'src', prefix: '/sources/', allow: {Back: ['Server.js']}});
+        const cfgFactory = await container.get('Fl32_Web_Back_Dto_Handler_Source$');
+        const cfg = cfgFactory.create({root: 'src', prefix: '/sources/', allow: {Back: ['Server.js']}});
+        await handler.init(cfg);
         const req = {url: '/sources/Back/Server.js'};
         const res = new MockRes();
         const ok = await handler.handle(req, res);


### PR DESCRIPTION
## Summary
- add `Fl32_Web_Back_Dto_Handler_Source` factory for configuration
- refactor `Fl32_Web_Back_Handler_Source.init` to use DTO
- update README sample to use the factory
- update unit tests for handler
- add unit test for the new DTO factory
- move allow-map casting logic to `Fl32_Web_Back_Helper_Cast` utility

## Testing
- `npx eslint src/`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6858dea76d6c832d8f4c85fa8f599d1d