### PR TITLE
Refactor Static handler into modular structure

### DIFF
--- a/src/Back/Handler/Static.js
+++ b/src/Back/Handler/Static.js
@@ -1,191 +1,65 @@
 /**
- * Universal file handler serving files from multiple sources.
- * Supports allow lists and directory index fallbacks.
+ * Universal file handler serving files from multiple sources using helper modules.
  *
  * @implements Fl32_Web_Back_Api_Handler
  */
 export default class Fl32_Web_Back_Handler_Static {
     /* eslint-disable jsdoc/require-param-description,jsdoc/check-param-names */
     /**
-     * @param {typeof import('node:fs')} fs - Node.js file system module.
-     * @param {typeof import('node:http2')} http2
-     * @param {typeof import('node:path')} path - Node.js path module.
-     * @param {Fl32_Web_Back_Logger} logger - Logger instance.
-     * @param {Fl32_Web_Back_Helper_Mime} helpMime - MIME helper for content type resolution.
-     * @param {Fl32_Web_Back_Helper_Respond} respond - Response helper with status utilities.
-     * @param {Fl32_Web_Back_Dto_Handler_Info} dtoInfo - DTO factory for handler registration.
-     * @param {Fl32_Web_Back_Dto_Handler_Source} dtoSource - DTO factory for source configs.
-     * @param {typeof Fl32_Web_Back_Enum_Stage} STAGE - Enum of handler stages.
+     * @param {Fl32_Web_Back_Handler_Static_A_Registry} registry
+     * @param {Fl32_Web_Back_Handler_Static_A_FileService} fileService
+     * @param {Fl32_Web_Back_Helper_Respond} respond
+     * @param {Fl32_Web_Back_Logger} logger
+     * @param {Fl32_Web_Back_Dto_Handler_Info} dtoInfo
+     * @param {typeof Fl32_Web_Back_Enum_Stage} STAGE
      */
     constructor(
         {
-            'node:fs': fs,
-            'node:http2': http2,
-            'node:path': path,
-            Fl32_Web_Back_Logger$: logger,
-            Fl32_Web_Back_Helper_Mime$: helpMime,
+            Fl32_Web_Back_Handler_Static_A_Registry$: registry,
+            Fl32_Web_Back_Handler_Static_A_FileService$: fileService,
             Fl32_Web_Back_Helper_Respond$: respond,
+            Fl32_Web_Back_Logger$: logger,
             Fl32_Web_Back_Dto_Handler_Info$: dtoInfo,
-            Fl32_Web_Back_Dto_Handler_Source$: dtoSource,
             Fl32_Web_Back_Enum_Stage$: STAGE,
         }
     ) {
         /* eslint-enable jsdoc/check-param-names */
-        // VARS
-        const {promises: fsp} = fs;
-        const {constants: H2} = http2;
-        const {
-            HTTP2_HEADER_CONTENT_LENGTH,
-            HTTP2_HEADER_CONTENT_TYPE,
-            HTTP2_HEADER_LAST_MODIFIED,
-            HTTP_STATUS_OK,
-        } = H2;
+        this._registry = registry;
+        this._fileService = fileService;
+        this._respond = respond;
+        this._logger = logger;
 
-        /**
-         * Handler registration info.
-         * @type {Fl32_Web_Back_Dto_Handler_Info.Dto}
-         */
         const _info = dtoInfo.create();
         _info.name = this.constructor.name;
         _info.stage = STAGE.PROCESS;
         Object.freeze(_info);
 
         /**
-         * Sources configuration sorted by prefix length.
-         * @type {{root: string, prefix: string, allow?: Record<string,string[]>, defaults: string[]}[]}
-         */
-        let _sources = [];
-
-        /**
-         * Global default index file names.
-         * @type {string[]}
-         */
-        const _defaultFiles = ['index.html', 'index.htm', 'index.txt'];
-
-
-        /**
-         * Handles the incoming request by attempting to serve a static file.
+         * Initialize registry with provided sources.
          *
-         * @param {module:http.IncomingMessage|module:http2.Http2ServerRequest} req - HTTP request object.
-         * @param {module:http.ServerResponse|module:http2.Http2ServerResponse} res - HTTP response object.
-         * @returns {Promise<boolean>} - True if the file was served, false otherwise.
-         */
-        this.handle = async function (req, res) {
-            if (!respond.isWritable(res)) return false;
-
-            try {
-                const urlPath = decodeURIComponent(req.url.split('?')[0]);
-
-                for (const src of _sources) {
-                    if (!urlPath.startsWith(src.prefix)) continue;
-
-                    const rel = urlPath.slice(src.prefix.length);
-                    if (rel.includes('..') || path.isAbsolute(rel)) {
-                        logger.warn(`Static access denied: ${rel}`);
-                        return false;
-                    }
-
-                    if (src.allow) {
-                        let pkg; let subPath;
-                        for (const key of Object.keys(src.allow)) {
-                            if (rel === key || rel.startsWith(`${key}/`)) {
-                                pkg = key;
-                                subPath = rel.slice(key.length);
-                                if (subPath.startsWith('/')) subPath = subPath.slice(1);
-                                break;
-                            }
-                        }
-                        if (!pkg) return false;
-
-                        const rules = src.allow[pkg] || [];
-                        let allowed = false;
-                        if (rules.includes('.')) {
-                            allowed = true;
-                        } else {
-                            for (const p of rules) {
-                                if (subPath === p || subPath.startsWith(`${p}/`)) {
-                                    allowed = true;
-                                    break;
-                                }
-                            }
-                        }
-                        if (!allowed) return false;
-                    }
-
-                    let fsPath = path.resolve(src.root, rel);
-                    if (!fsPath.startsWith(src.root)) {
-                        logger.warn(`Static access denied: ${rel}`);
-                        return false;
-                    }
-
-                    let stat;
-                    try {
-                        stat = await fsp.stat(fsPath);
-                    } catch {
-                        continue;
-                    }
-
-                    if (stat.isDirectory()) {
-                        for (const file of src.defaults) {
-                            const candidate = path.join(fsPath, file);
-                            try {
-                                const s = await fsp.stat(candidate);
-                                if (s.isFile()) {
-                                    fsPath = candidate;
-                                    stat = s;
-                                    break;
-                                }
-                            } catch {
-                                // ignore and continue
-                            }
-                        }
-                        if (!stat.isFile()) continue;
-                    }
-
-                    if (!stat.isFile()) continue;
-
-                    const stream = fs.createReadStream(fsPath);
-                    const ext = path.extname(fsPath).toLowerCase();
-                    const headers = {
-                        [HTTP2_HEADER_CONTENT_LENGTH]: stat.size,
-                        [HTTP2_HEADER_CONTENT_TYPE]: helpMime.getByExt(ext),
-                        [HTTP2_HEADER_LAST_MODIFIED]: stat.mtime.toUTCString(),
-                    };
-                    res.writeHead(HTTP_STATUS_OK, headers);
-                    stream.pipe(res);
-                    return true;
-                }
-
-                return false;
-            } catch (e) {
-                logger.exception(e);
-                return false;
-            }
-        };
-
-        /**
-         * Initializes the handler with list of sources.
-         * Each source may specify root, prefix, allow map and default index files.
-         *
-         * @param {{sources: object[]} } params
+         * @param {{sources: Fl32_Web_Back_Dto_Handler_Source.Dto[]}} params
          * @returns {Promise<void>}
          */
-        this.init = async function ({sources = []} = {}) {
-            _sources = sources.map(src => {
-                const dto = dtoSource.create(src);
-                const res = {};
-                res.root = path.resolve(dto.root);
-                res.prefix = dto.prefix || '/';
-                if (!res.prefix.endsWith('/')) res.prefix += '/';
-                res.allow = dto.allow;
-                const defs = (dto.defaults.length) ? dto.defaults : _defaultFiles;
-                res.defaults = defs;
-                return res;
-            }).sort((a, b) => b.prefix.length - a.prefix.length);
+        this.init = async ({sources = []} = {}) => {
+            this._registry.setConfigs(sources);
         };
 
         /**
-         * Returns the handler registration info.
+         * Attempt to handle incoming request.
+         *
+         * @param {module:http.IncomingMessage|module:http2.Http2ServerRequest} req
+         * @param {module:http.ServerResponse|module:http2.Http2ServerResponse} res
+         * @returns {Promise<boolean>} True if file served
+         */
+        this.handle = async (req, res) => {
+            if (!this._respond.isWritable(res)) return false;
+            const urlPath = decodeURIComponent(req.url.split('?')[0]);
+            const match = this._registry.find(urlPath);
+            if (!match) return false;
+            return this._fileService.serve(match.config, match.rel, req, res);
+        };
+
+        /**
          * @returns {Fl32_Web_Back_Dto_Handler_Info.Dto}
          */
         this.getRegistrationInfo = () => _info;

--- a/src/Back/Handler/Static/A/Config.js
+++ b/src/Back/Handler/Static/A/Config.js
@@ -1,0 +1,59 @@
+export default class Fl32_Web_Back_Handler_Static_A_Config {
+    static DEFAULT_FILES = ['index.html', 'index.htm', 'index.txt'];
+    /* eslint-disable jsdoc/require-param-description,jsdoc/check-param-names */
+    /**
+     * @param {typeof import('node:path')} path
+     */
+    constructor(
+        {
+            'node:path': path,
+        }
+    ) {
+        /* eslint-enable jsdoc/check-param-names */
+        this._path = path;
+    }
+
+    /**
+     * Normalize DTO fields into configuration object.
+     *
+     * @param {Fl32_Web_Back_Dto_Handler_Source.Dto} dto
+     * @returns {{root:string,prefix:string,allow?:Record<string,string[]>,defaults:string[]}}
+     * @throws {Error} When required fields are missing or invalid.
+     */
+    create(dto) {
+        if (!dto || typeof dto.root !== 'string') {
+            throw new Error('Source root must be a string');
+        }
+        let prefix = dto.prefix ?? '/';
+        if (typeof prefix !== 'string') {
+            throw new Error('Source prefix must be a string');
+        }
+        if (!prefix.endsWith('/')) prefix += '/';
+
+        const root = this._path.resolve(dto.root);
+
+        let allow;
+        if (dto.allow !== undefined) {
+            if (typeof dto.allow !== 'object' || dto.allow === null || Array.isArray(dto.allow)) {
+                throw new Error('Allow must be an object');
+            }
+            for (const [k, arr] of Object.entries(dto.allow)) {
+                if (!Array.isArray(arr) || arr.some(v => typeof v !== 'string')) {
+                    throw new Error(`Invalid allow list for ${k}`);
+                }
+            }
+            allow = dto.allow;
+        }
+
+        let defaults = dto.defaults;
+        if (defaults !== undefined && defaults.length) {
+            if (!Array.isArray(defaults) || defaults.some(v => typeof v !== 'string')) {
+                throw new Error('Defaults must be an array of strings');
+            }
+        } else {
+            defaults = Fl32_Web_Back_Handler_Static_A_Config.DEFAULT_FILES;
+        }
+
+        return {root, prefix, allow, defaults};
+    }
+}

--- a/src/Back/Handler/Static/A/Fallback.js
+++ b/src/Back/Handler/Static/A/Fallback.js
@@ -1,0 +1,41 @@
+export default class Fl32_Web_Back_Handler_Static_A_Fallback {
+    /* eslint-disable jsdoc/require-param-description,jsdoc/check-param-names */
+    /**
+     * @param {typeof import('node:fs')} fs
+     * @param {typeof import('node:path')} path
+     */
+    constructor(
+        {
+            'node:fs': fs,
+            'node:path': path,
+        }
+    ) {
+        /* eslint-enable jsdoc/check-param-names */
+        this._fsp = fs.promises;
+        this._path = path;
+    }
+
+    /**
+     * Apply default index fallback for directories.
+     *
+     * @param {string} fsPath
+     * @param {string[]} defaults
+     * @returns {Promise<string|null>} Path to existing file or null.
+     */
+    async apply(fsPath, defaults) {
+        let stat;
+        try { stat = await this._fsp.stat(fsPath); } catch { return null; }
+
+        if (stat.isDirectory()) {
+            for (const file of defaults) {
+                const candidate = this._path.join(fsPath, file);
+                try {
+                    const s = await this._fsp.stat(candidate);
+                    if (s.isFile()) return candidate;
+                } catch { /* ignore */ }
+            }
+            return null;
+        }
+        return stat.isFile() ? fsPath : null;
+    }
+}

--- a/src/Back/Handler/Static/A/FileService.js
+++ b/src/Back/Handler/Static/A/FileService.js
@@ -1,0 +1,70 @@
+export default class Fl32_Web_Back_Handler_Static_A_FileService {
+    /* eslint-disable jsdoc/require-param-description,jsdoc/check-param-names */
+    /**
+     * @param {typeof import('node:fs')} fs
+     * @param {typeof import('node:http2')} http2
+     * @param {typeof import('node:path')} path
+     * @param {Fl32_Web_Back_Logger} logger
+     * @param {Fl32_Web_Back_Helper_Mime} helpMime
+     * @param {Fl32_Web_Back_Handler_Static_A_Resolver} resolver
+     * @param {Fl32_Web_Back_Handler_Static_A_Fallback} fallback
+     */
+    constructor(
+        {
+            'node:fs': fs,
+            'node:http2': http2,
+            'node:path': path,
+            Fl32_Web_Back_Logger$: logger,
+            Fl32_Web_Back_Helper_Mime$: helpMime,
+            Fl32_Web_Back_Handler_Static_A_Resolver$: resolver,
+            Fl32_Web_Back_Handler_Static_A_Fallback$: fallback,
+        }
+    ) {
+        /* eslint-enable jsdoc/check-param-names */
+        this._fs = fs;
+        this._fsp = fs.promises;
+        this._path = path;
+        this._logger = logger;
+        this._helpMime = helpMime;
+        this._resolver = resolver;
+        this._fallback = fallback;
+        const {constants: H2} = http2;
+        this._H2 = H2;
+    }
+
+    /**
+     * Serve a file for given config and relative path.
+     *
+     * @param {*} config
+     * @param {string} rel
+     * @param {*} req
+     * @param {*} res
+     * @returns {Promise<boolean>} true if served
+     */
+    async serve(config, rel, req, res) {
+        try {
+            let fsPath = this._resolver.resolve(config, rel);
+            if (!fsPath) return false;
+
+            fsPath = await this._fallback.apply(fsPath, config.defaults);
+            if (!fsPath) return false;
+
+            const stat = await this._fsp.stat(fsPath);
+            if (!stat.isFile()) return false;
+
+            const stream = this._fs.createReadStream(fsPath);
+            const ext = this._path.extname(fsPath).toLowerCase();
+            const headers = {
+                [this._H2.HTTP2_HEADER_CONTENT_LENGTH]: stat.size,
+                [this._H2.HTTP2_HEADER_CONTENT_TYPE]: this._helpMime.getByExt(ext),
+                [this._H2.HTTP2_HEADER_LAST_MODIFIED]: stat.mtime.toUTCString(),
+            };
+            res.writeHead(this._H2.HTTP_STATUS_OK, headers);
+            stream.pipe(res);
+            return true;
+        } catch (e) {
+            this._logger.exception(e);
+            return false;
+        }
+    }
+}

--- a/src/Back/Handler/Static/A/Registry.js
+++ b/src/Back/Handler/Static/A/Registry.js
@@ -1,0 +1,43 @@
+export default class Fl32_Web_Back_Handler_Static_A_Registry {
+    /* eslint-disable jsdoc/require-param-description,jsdoc/check-param-names */
+    /**
+     * @param {Fl32_Web_Back_Handler_Static_A_Config} configFactory
+     */
+    constructor(
+        {
+            Fl32_Web_Back_Handler_Static_A_Config$: configFactory,
+        }
+    ) {
+        /* eslint-enable jsdoc/check-param-names */
+        this._factory = configFactory;
+        /** @type {ReturnType<Fl32_Web_Back_Handler_Static_A_Config['create']>[]} */
+        let _configs = [];
+
+        /**
+         * Store configuration list sorted by prefix length.
+         *
+         * @param {Fl32_Web_Back_Dto_Handler_Source.Dto[]} dtoList
+         */
+        this.setConfigs = function (dtoList = []) {
+            _configs = dtoList
+                .map(dto => this._factory.create(dto))
+                .sort((a, b) => b.prefix.length - a.prefix.length);
+        };
+
+        /**
+         * Find configuration by matching URL prefix.
+         *
+         * @param {string} url
+         * @returns {{config: *, rel: string}|null}
+         */
+        this.find = function (url) {
+            for (const cfg of _configs) {
+                if (url.startsWith(cfg.prefix)) {
+                    const rel = url.slice(cfg.prefix.length);
+                    return {config: cfg, rel};
+                }
+            }
+            return null;
+        };
+    }
+}

--- a/src/Back/Handler/Static/A/Resolver.js
+++ b/src/Back/Handler/Static/A/Resolver.js
@@ -1,0 +1,62 @@
+export default class Fl32_Web_Back_Handler_Static_A_Resolver {
+    /* eslint-disable jsdoc/require-param-description,jsdoc/check-param-names */
+    /**
+     * @param {typeof import('node:path')} path
+     */
+    constructor(
+        {
+            'node:path': path,
+        }
+    ) {
+        /* eslint-enable jsdoc/check-param-names */
+        this._path = path;
+    }
+
+    /**
+     * Resolve filesystem path for given config and relative URL part.
+     * Applies allow rules and security checks.
+     *
+     * @param {{root:string,prefix:string,allow?:Record<string,string[]>}} config
+     * @param {string} rel
+     * @returns {string|null} Absolute path or null when not allowed.
+     * @throws {Error} On path traversal attempts.
+     */
+    resolve(config, rel) {
+        if (rel.includes('..') || this._path.isAbsolute(rel)) {
+            throw new Error('Static access denied');
+        }
+
+        if (config.allow) {
+            let pkg; let subPath = '';
+            for (const key of Object.keys(config.allow)) {
+                if (rel === key || rel.startsWith(`${key}/`)) {
+                    pkg = key;
+                    subPath = rel.slice(key.length);
+                    if (subPath.startsWith('/')) subPath = subPath.slice(1);
+                    break;
+                }
+            }
+            if (!pkg) return null;
+
+            const rules = config.allow[pkg] || [];
+            let allowed = false;
+            if (rules.includes('.')) {
+                allowed = true;
+            } else {
+                for (const p of rules) {
+                    if (subPath === p || subPath.startsWith(`${p}/`)) {
+                        allowed = true;
+                        break;
+                    }
+                }
+            }
+            if (!allowed) return null;
+        }
+
+        const fsPath = this._path.resolve(config.root, rel);
+        if (!fsPath.startsWith(config.root)) {
+            throw new Error('Resolved path is outside the root');
+        }
+        return fsPath;
+    }
+}

--- a/test/Back/Handler/Static/A/Config.test.js
+++ b/test/Back/Handler/Static/A/Config.test.js
@@ -1,0 +1,21 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import Config from '../../../../../src/Back/Handler/Static/A/Config.js';
+
+describe('Static A Config', () => {
+    it('normalizes prefix and defaults', () => {
+        const factory = new Config({'node:path': path});
+        const dto = {root: './r', prefix: '/p', allow: {'.':['.']}, defaults: []};
+        const cfg = factory.create(dto);
+        assert.strictEqual(cfg.root, path.resolve('./r'));
+        assert.strictEqual(cfg.prefix, '/p/');
+        assert.deepStrictEqual(cfg.defaults, ['index.html','index.htm','index.txt']);
+    });
+
+    it('throws on invalid data', () => {
+        const factory = new Config({'node:path': path});
+        assert.throws(() => factory.create({prefix:'/'}), /root must be a string/);
+        assert.throws(() => factory.create({root:'a', prefix: 5}), /prefix must be a string/i);
+    });
+});

--- a/test/Back/Handler/Static/A/Fallback.test.js
+++ b/test/Back/Handler/Static/A/Fallback.test.js
@@ -1,0 +1,45 @@
+import {describe, it, beforeEach} from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import Fallback from '../../../../../src/Back/Handler/Static/A/Fallback.js';
+
+const normalize = p => {
+    p = p.replace(/\\/g,'/');
+    p = p.replace(/\/+/g,'/');
+    if(p.length>1 && p.endsWith('/')) p=p.slice(0,-1);
+    return p;
+};
+
+let files; let stat;
+function reset(){ files={}; stat={}; }
+function addFile(p){ p=normalize(p); files[p]=true; stat[p]={isFile:()=>true,isDirectory:()=>false}; }
+function addDir(p){ p=normalize(p); stat[p]={isFile:()=>false,isDirectory:()=>true}; }
+
+const mockFs = {
+    promises: {
+        stat: async (p)=>{
+            p=normalize(p);
+            if(!stat[p]) throw new Error('ENOENT');
+            return stat[p];
+        }
+    }
+};
+
+describe('Static A Fallback', () => {
+    beforeEach(reset);
+
+    it('returns index file for directory', async () => {
+        addDir('/d');
+        addFile('/d/index.html');
+        const fb = new Fallback({'node:fs': mockFs, 'node:path': path});
+        const res = await fb.apply('/d', ['index.html']);
+        assert.strictEqual(res, normalize('/d/index.html'));
+    });
+
+    it('returns null when nothing found', async () => {
+        addDir('/x');
+        const fb = new Fallback({'node:fs': mockFs, 'node:path': path});
+        const res = await fb.apply('/x', ['a.html']);
+        assert.strictEqual(res, null);
+    });
+});

--- a/test/Back/Handler/Static/A/FileService.test.js
+++ b/test/Back/Handler/Static/A/FileService.test.js
@@ -1,0 +1,69 @@
+import {describe, it, beforeEach} from 'node:test';
+import assert from 'node:assert/strict';
+import FileService from '../../../../../src/Back/Handler/Static/A/FileService.js';
+import Resolver from '../../../../../src/Back/Handler/Static/A/Resolver.js';
+import Fallback from '../../../../../src/Back/Handler/Static/A/Fallback.js';
+
+class EventEmitter { constructor(){this._e={};} on(e,f){(this._e[e] ||= []).push(f);} emit(e,...a){(this._e[e]||[]).forEach(f=>f(...a));} }
+
+const mockHttp2 = { constants:{ HTTP2_HEADER_CONTENT_LENGTH:'len', HTTP2_HEADER_CONTENT_TYPE:'type', HTTP2_HEADER_LAST_MODIFIED:'mod', HTTP_STATUS_OK:200 } };
+
+const normalize=p=>{p=p.replace(/\\/g,'/');p=p.replace(/\/+/g,'/');if(p.length>1&&p.endsWith('/'))p=p.slice(0,-1);return p;};
+const mockPath = { resolve:(...a)=>normalize(a.filter(Boolean).join('/')), join:(...a)=>normalize(a.filter(Boolean).join('/')), extname:p=>{const b=p.split('/').pop();const i=b.lastIndexOf('.');return i>-1?b.slice(i):'';}, isAbsolute:p=>p.startsWith('/') };
+
+let files;let stat;
+function reset(){files={};stat={};}
+function addFile(p,c){p=mockPath.resolve(p);files[p]=c;stat[p]={isFile:()=>true,isDirectory:()=>false,size:Buffer.byteLength(c),mtime:new Date()};}
+function addDir(p){p=mockPath.resolve(p);stat[p]={isFile:()=>false,isDirectory:()=>true,size:0,mtime:new Date()};}
+
+const mockFs={
+  promises:{
+    stat:async p=>{p=mockPath.resolve(p);if(!stat[p]) throw new Error('ENOENT');return stat[p];}
+  },
+  createReadStream:p=>({
+    pipe(res){setImmediate(()=>{if(files[p]) res.write(files[p]);res.end();});}
+  })
+};
+
+class MockRes extends EventEmitter{constructor(){super();this.data='';this.status=undefined;this.headers=undefined;this._hs=false;this._ended=false;}get headersSent(){return this._hs;}get writableEnded(){return this._ended;}writeHead(s,h){this.status=s;this.headers=h;this._hs=true;}write(c){this.data+=c;}end(c){if(c) this.write(c);this._ended=true;this.emit('finish');}}
+
+const logger={exception:()=>{}};
+const mime={getByExt:()=>"text/plain"};
+
+let service;
+
+beforeEach(() => {
+  reset();
+  const resolver = new Resolver({'node:path': mockPath});
+  const fb = new Fallback({'node:fs': mockFs, 'node:path': mockPath});
+  service = new FileService({
+    'node:fs': mockFs,
+    'node:http2': mockHttp2,
+    'node:path': mockPath,
+    Fl32_Web_Back_Logger$: logger,
+    Fl32_Web_Back_Helper_Mime$: mime,
+    Fl32_Web_Back_Handler_Static_A_Resolver$: resolver,
+    Fl32_Web_Back_Handler_Static_A_Fallback$: fb,
+  });
+});
+
+describe('Static A FileService', () => {
+  it('serves existing file', async () => {
+    addFile('/root/a.txt','A');
+    const config={root:'/root',prefix:'/p/',defaults:['index.html']};
+    const res=new MockRes();
+    const ok=await service.serve(config,'a.txt',{},res); 
+    await new Promise(r=>res.on('finish',r));
+    assert.ok(ok);
+    assert.strictEqual(res.status,200);
+    assert.strictEqual(res.data,'A');
+  });
+
+  it('returns false when not found', async () => {
+    addDir('/root');
+    const config={root:'/root',prefix:'/p/',defaults:['index.html']};
+    const res=new MockRes();
+    const ok=await service.serve(config,'missing.txt',{},res);
+    assert.strictEqual(ok,false);
+  });
+});

--- a/test/Back/Handler/Static/A/Registry.test.js
+++ b/test/Back/Handler/Static/A/Registry.test.js
@@ -1,0 +1,22 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import Registry from '../../../../../src/Back/Handler/Static/A/Registry.js';
+import Config from '../../../../../src/Back/Handler/Static/A/Config.js';
+
+describe('Static A Registry', () => {
+    it('sorts configs and finds matches', () => {
+        const cfgFactory = new Config({'node:path': path});
+        const registry = new Registry({Fl32_Web_Back_Handler_Static_A_Config$: cfgFactory});
+        const list = [
+            {root:'/a', prefix:'/files/', defaults:[]},
+            {root:'/b', prefix:'/files/special/', defaults:[]},
+        ];
+        registry.setConfigs(list);
+        const match = registry.find('/files/special/test.txt');
+        assert.ok(match);
+        assert.strictEqual(match.config.root, path.resolve('/b'));
+        assert.strictEqual(match.rel, 'test.txt');
+        assert.strictEqual(registry.find('/unknown'), null);
+    });
+});

--- a/test/Back/Handler/Static/A/Resolver.test.js
+++ b/test/Back/Handler/Static/A/Resolver.test.js
@@ -1,0 +1,23 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import Resolver from '../../../../../src/Back/Handler/Static/A/Resolver.js';
+
+describe('Static A Resolver', () => {
+    const resolver = new Resolver({'node:path': path});
+    const config = {root: path.resolve('/root'), prefix:'/p/', allow:{pkg:['a.txt']}};
+
+    it('resolves allowed path', () => {
+        const p = resolver.resolve(config, 'pkg/a.txt');
+        assert.strictEqual(p, path.resolve('/root/pkg/a.txt'));
+    });
+
+    it('blocks disallowed path', () => {
+        const p = resolver.resolve(config, 'pkg/b.txt');
+        assert.strictEqual(p, null);
+    });
+
+    it('throws on traversal', () => {
+        assert.throws(() => resolver.resolve(config, '../x'), /access denied/);
+    });
+});

--- a/test/Back/Handler/Static/Static.test.js
+++ b/test/Back/Handler/Static/Static.test.js
@@ -1,0 +1,108 @@
+import {describe, it, beforeEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {buildTestContainer} from '../../../unit/common.js';
+
+class EventEmitter { constructor(){this._e={};} on(e,f){(this._e[e] ||= []).push(f);} emit(e,...a){(this._e[e]||[]).forEach(fn=>fn(...a));} }
+
+const mockHttp2={constants:{HTTP2_HEADER_CONTENT_LENGTH:'content-length',HTTP2_HEADER_CONTENT_TYPE:'content-type',HTTP2_HEADER_LAST_MODIFIED:'last-modified',HTTP_STATUS_OK:200}};
+const normalize=p=>{p=p.replace(/\\/g,'/');p=p.replace(/\/+/g,'/');if(p.length>1&&p.endsWith('/'))p=p.slice(0,-1);return p;};
+const mockPath={resolve:(...a)=>normalize(a.filter(Boolean).join('/')),join:(...a)=>normalize(a.filter(Boolean).join('/')),isAbsolute:p=>p.startsWith('/'),extname:p=>{const b=p.split('/').pop();const i=b.lastIndexOf('.');return i>-1?b.slice(i):'';}};
+
+let files;let stat;function resetFS(){files={};stat={};}
+function addDir(p){p=mockPath.resolve(p);stat[p]={isFile:()=>false,isDirectory:()=>true,size:0,mtime:new Date()};}
+function addFile(p,c){p=mockPath.resolve(p);files[p]=c;stat[p]={isFile:()=>true,isDirectory:()=>false,size:Buffer.byteLength(c),mtime:new Date()};}
+
+const mockFs={
+  promises:{
+    stat:async p=>{p=mockPath.resolve(p);if(!stat[p]) throw new Error('ENOENT');return stat[p];}
+  },
+  createReadStream:p=>({pipe(res){setImmediate(()=>{if(files[p]) res.write(files[p]);res.end();});}})
+};
+
+class MockRes extends EventEmitter{constructor(){super();this.data=Buffer.alloc(0);this.statusCode=undefined;this.headers=undefined;this._sent=false;this._end=false;}get headersSent(){return this._sent;}get writableEnded(){return this._end;}writeHead(s,h){this.statusCode=s;this.headers=h;this._sent=true;}write(c){this.data=Buffer.concat([this.data,Buffer.from(c)]);}end(c){if(c) this.write(c);this._end=true;this.emit('finish');}}
+
+describe('Fl32_Web_Back_Handler_Static (modular)', () => {
+  let container; const log=[];
+
+  beforeEach(() => {
+    container = buildTestContainer();
+    container.register('node:fs', mockFs);
+    container.register('node:http2', mockHttp2);
+    container.register('node:path', mockPath);
+    container.register('Fl32_Web_Back_Logger$', {
+      warn: (...a)=>log.push(['warn',...a]),
+      exception: (...a)=>log.push(['exception',...a])
+    });
+    log.length=0; resetFS();
+  });
+
+  it('should match sources by prefix length', async () => {
+    addDir('/a'); addFile('/a/test.txt','A');
+    addDir('/b'); addFile('/b/test.txt','B');
+    const handler = await container.get('Fl32_Web_Back_Handler_Static$');
+    const Cfg = await container.get('Fl32_Web_Back_Dto_Handler_Source$');
+    await handler.init({sources:[
+      Cfg.create({prefix:'/files/',root:'/a',allow:{'.':['.']}}),
+      Cfg.create({prefix:'/files/special/',root:'/b',allow:{'.':['.']}}),
+    ]});
+    const res=new MockRes();
+    const ok=await handler.handle({url:'/files/special/test.txt'},res);
+    await new Promise(r=>res.on('finish',r));
+    assert.strictEqual(ok,true);
+    assert.strictEqual(res.data.toString(),'B');
+  });
+
+  it('should enforce allow list rules', async () => {
+    addFile('src/Back/Server.js','class Fl32_Web_Back_Server {}');
+    addFile('src/Back/Handler/Static.js','static');
+    const handler=await container.get('Fl32_Web_Back_Handler_Static$');
+    const Cfg=await container.get('Fl32_Web_Back_Dto_Handler_Source$');
+    await handler.init({sources:[Cfg.create({root:'src',prefix:'/s/',allow:{Back:['Server.js']}})]});
+    const resOk=new MockRes();
+    const ok=await handler.handle({url:'/s/Back/Server.js'},resOk);
+    await new Promise(r=>resOk.on('finish',r));
+    assert.strictEqual(ok,true);
+    const resBad=new MockRes();
+    const bad=await handler.handle({url:'/s/Back/Handler/Static.js'},resBad);
+    assert.strictEqual(bad,false);
+    assert.strictEqual(resBad.headersSent,false);
+  });
+
+  it('should allow full access with dot rule', async () => {
+    addFile('src/Back/Server.js','class Fl32_Web_Back_Server {}');
+    const handler=await container.get('Fl32_Web_Back_Handler_Static$');
+    const Cfg=await container.get('Fl32_Web_Back_Dto_Handler_Source$');
+    await handler.init({sources:[Cfg.create({root:'src',prefix:'/full/',allow:{Back:['.']}})]});
+    const res=new MockRes();
+    const ok=await handler.handle({url:'/full/Back/Server.js'},res);
+    await new Promise(r=>res.on('finish',r));
+    assert.strictEqual(ok,true);
+    assert.match(res.data.toString(),/class Fl32_Web_Back_Server/);
+  });
+
+  it('should serve index files in directories', async () => {
+    addDir('/dir'); addDir('/dir/d'); addFile('/dir/d/index.txt','INDEX');
+    const handler=await container.get('Fl32_Web_Back_Handler_Static$');
+    const Cfg=await container.get('Fl32_Web_Back_Dto_Handler_Source$');
+    await handler.init({sources:[Cfg.create({root:'/dir',prefix:'/w/',defaults:['index.txt'],allow:{'.':['.']}})]});
+    const res=new MockRes();
+    const ok=await handler.handle({url:'/w/d/'},res);
+    await new Promise(r=>res.on('finish',r));
+    assert.strictEqual(ok,true);
+    assert.strictEqual(res.data.toString(),'INDEX');
+  });
+
+  it('should reject path traversal and unmatched prefixes', async () => {
+    addFile('/safe/file.txt','ok');
+    const handler=await container.get('Fl32_Web_Back_Handler_Static$');
+    const Cfg=await container.get('Fl32_Web_Back_Dto_Handler_Source$');
+    await handler.init({sources:[Cfg.create({root:'/safe',prefix:'/p/',allow:{'.':['.']}})]});
+    const res1=new MockRes();
+    const bad1=await handler.handle({url:'/p/../file.txt'},res1);
+    assert.strictEqual(bad1,false);
+    const res2=new MockRes();
+    const bad2=await handler.handle({url:'/x/file.txt'},res2);
+    assert.strictEqual(bad2,false);
+    assert.strictEqual(res2.headersSent,false);
+  });
+});


### PR DESCRIPTION
## Summary
- break down `Static` handler into helper classes under `Static/A`
- implement configuration parsing, registry, resolver, fallback and file service
- update `Static` handler to use new helpers
- add unit tests for each helper and the new handler

## Testing
- `node --test $(find test -name '*.test.js')` *(fails: Fl32_Web_Back_Handler_Static (modular) tests cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685b9cd29898832d90f2e1f271142dda