### PR TITLE
Refactor DI bindings to closures

### DIFF
--- a/src/Back/Handler/Static.js
+++ b/src/Back/Handler/Static.js
@@ -24,10 +24,6 @@ export default class Fl32_Web_Back_Handler_Static {
         }
     ) {
         /* eslint-enable jsdoc/check-param-names */
-        this._registry = registry;
-        this._fileService = fileService;
-        this._respond = respond;
-        this._logger = logger;
 
         const _info = dtoInfo.create();
         _info.name = this.constructor.name;
@@ -41,7 +37,7 @@ export default class Fl32_Web_Back_Handler_Static {
          * @returns {Promise<void>}
          */
         this.init = async ({sources = []} = {}) => {
-            this._registry.setConfigs(sources);
+            registry.setConfigs(sources);
         };
 
         /**
@@ -52,11 +48,11 @@ export default class Fl32_Web_Back_Handler_Static {
          * @returns {Promise<boolean>} True if file served
          */
         this.handle = async (req, res) => {
-            if (!this._respond.isWritable(res)) return false;
+            if (!respond.isWritable(res)) return false;
             const urlPath = decodeURIComponent(req.url.split('?')[0]);
-            const match = this._registry.find(urlPath);
+            const match = registry.find(urlPath);
             if (!match) return false;
-            return this._fileService.serve(match.config, match.rel, req, res);
+            return fileService.serve(match.config, match.rel, req, res);
         };
 
         /**

--- a/src/Back/Handler/Static/A/Config.js
+++ b/src/Back/Handler/Static/A/Config.js
@@ -10,50 +10,49 @@ export default class Fl32_Web_Back_Handler_Static_A_Config {
         }
     ) {
         /* eslint-enable jsdoc/check-param-names */
-        this._path = path;
-    }
 
-    /**
-     * Normalize DTO fields into configuration object.
-     *
-     * @param {Fl32_Web_Back_Dto_Handler_Source.Dto} dto
-     * @returns {{root:string,prefix:string,allow?:Record<string,string[]>,defaults:string[]}}
-     * @throws {Error} When required fields are missing or invalid.
-     */
-    create(dto) {
-        if (!dto || typeof dto.root !== 'string') {
-            throw new Error('Source root must be a string');
-        }
-        let prefix = dto.prefix ?? '/';
-        if (typeof prefix !== 'string') {
-            throw new Error('Source prefix must be a string');
-        }
-        if (!prefix.endsWith('/')) prefix += '/';
-
-        const root = this._path.resolve(dto.root);
-
-        let allow;
-        if (dto.allow !== undefined) {
-            if (typeof dto.allow !== 'object' || dto.allow === null || Array.isArray(dto.allow)) {
-                throw new Error('Allow must be an object');
+        /**
+         * Normalize DTO fields into configuration object.
+         *
+         * @param {Fl32_Web_Back_Dto_Handler_Source.Dto} dto
+         * @returns {{root:string,prefix:string,allow?:Record<string,string[]>,defaults:string[]}}
+         * @throws {Error} When required fields are missing or invalid.
+         */
+        this.create = (dto) => {
+            if (!dto || typeof dto.root !== 'string') {
+                throw new Error('Source root must be a string');
             }
-            for (const [k, arr] of Object.entries(dto.allow)) {
-                if (!Array.isArray(arr) || arr.some(v => typeof v !== 'string')) {
-                    throw new Error(`Invalid allow list for ${k}`);
+            let prefix = dto.prefix ?? '/';
+            if (typeof prefix !== 'string') {
+                throw new Error('Source prefix must be a string');
+            }
+            if (!prefix.endsWith('/')) prefix += '/';
+
+            const root = path.resolve(dto.root);
+
+            let allow;
+            if (dto.allow !== undefined) {
+                if (typeof dto.allow !== 'object' || dto.allow === null || Array.isArray(dto.allow)) {
+                    throw new Error('Allow must be an object');
                 }
+                for (const [k, arr] of Object.entries(dto.allow)) {
+                    if (!Array.isArray(arr) || arr.some(v => typeof v !== 'string')) {
+                        throw new Error(`Invalid allow list for ${k}`);
+                    }
+                }
+                allow = dto.allow;
             }
-            allow = dto.allow;
-        }
 
-        let defaults = dto.defaults;
-        if (defaults !== undefined && defaults.length) {
-            if (!Array.isArray(defaults) || defaults.some(v => typeof v !== 'string')) {
-                throw new Error('Defaults must be an array of strings');
+            let defaults = dto.defaults;
+            if (defaults !== undefined && defaults.length) {
+                if (!Array.isArray(defaults) || defaults.some(v => typeof v !== 'string')) {
+                    throw new Error('Defaults must be an array of strings');
+                }
+            } else {
+                defaults = Fl32_Web_Back_Handler_Static_A_Config.DEFAULT_FILES;
             }
-        } else {
-            defaults = Fl32_Web_Back_Handler_Static_A_Config.DEFAULT_FILES;
-        }
 
-        return {root, prefix, allow, defaults};
+            return {root, prefix, allow, defaults};
+        };
     }
 }

--- a/src/Back/Handler/Static/A/Fallback.js
+++ b/src/Back/Handler/Static/A/Fallback.js
@@ -11,31 +11,29 @@ export default class Fl32_Web_Back_Handler_Static_A_Fallback {
         }
     ) {
         /* eslint-enable jsdoc/check-param-names */
-        this._fsp = fs.promises;
-        this._path = path;
-    }
 
-    /**
-     * Apply default index fallback for directories.
-     *
-     * @param {string} fsPath
-     * @param {string[]} defaults
-     * @returns {Promise<string|null>} Path to existing file or null.
-     */
-    async apply(fsPath, defaults) {
-        let stat;
-        try { stat = await this._fsp.stat(fsPath); } catch { return null; }
+        /**
+         * Apply default index fallback for directories.
+         *
+         * @param {string} fsPath
+         * @param {string[]} defaults
+         * @returns {Promise<string|null>} Path to existing file or null.
+         */
+        this.apply = async (fsPath, defaults) => {
+            let stat;
+            try { stat = await fs.promises.stat(fsPath); } catch { return null; }
 
-        if (stat.isDirectory()) {
-            for (const file of defaults) {
-                const candidate = this._path.join(fsPath, file);
-                try {
-                    const s = await this._fsp.stat(candidate);
-                    if (s.isFile()) return candidate;
-                } catch { /* ignore */ }
+            if (stat.isDirectory()) {
+                for (const file of defaults) {
+                    const candidate = path.join(fsPath, file);
+                    try {
+                        const s = await fs.promises.stat(candidate);
+                        if (s.isFile()) return candidate;
+                    } catch { /* ignore */ }
+                }
+                return null;
             }
-            return null;
-        }
-        return stat.isFile() ? fsPath : null;
+            return stat.isFile() ? fsPath : null;
+        };
     }
 }

--- a/src/Back/Handler/Static/A/FileService.js
+++ b/src/Back/Handler/Static/A/FileService.js
@@ -21,50 +21,42 @@ export default class Fl32_Web_Back_Handler_Static_A_FileService {
         }
     ) {
         /* eslint-enable jsdoc/check-param-names */
-        this._fs = fs;
-        this._fsp = fs.promises;
-        this._path = path;
-        this._logger = logger;
-        this._helpMime = helpMime;
-        this._resolver = resolver;
-        this._fallback = fallback;
         const {constants: H2} = http2;
-        this._H2 = H2;
-    }
 
-    /**
-     * Serve a file for given config and relative path.
-     *
-     * @param {*} config
-     * @param {string} rel
-     * @param {*} req
-     * @param {*} res
-     * @returns {Promise<boolean>} true if served
-     */
-    async serve(config, rel, req, res) {
-        try {
-            let fsPath = this._resolver.resolve(config, rel);
-            if (!fsPath) return false;
+        /**
+         * Serve a file for given config and relative path.
+         *
+         * @param {*} config
+         * @param {string} rel
+         * @param {*} req
+         * @param {*} res
+         * @returns {Promise<boolean>} true if served
+         */
+        this.serve = async (config, rel, req, res) => {
+            try {
+                let fsPath = resolver.resolve(config, rel);
+                if (!fsPath) return false;
 
-            fsPath = await this._fallback.apply(fsPath, config.defaults);
-            if (!fsPath) return false;
+                fsPath = await fallback.apply(fsPath, config.defaults);
+                if (!fsPath) return false;
 
-            const stat = await this._fsp.stat(fsPath);
-            if (!stat.isFile()) return false;
+                const stat = await fs.promises.stat(fsPath);
+                if (!stat.isFile()) return false;
 
-            const stream = this._fs.createReadStream(fsPath);
-            const ext = this._path.extname(fsPath).toLowerCase();
-            const headers = {
-                [this._H2.HTTP2_HEADER_CONTENT_LENGTH]: stat.size,
-                [this._H2.HTTP2_HEADER_CONTENT_TYPE]: this._helpMime.getByExt(ext),
-                [this._H2.HTTP2_HEADER_LAST_MODIFIED]: stat.mtime.toUTCString(),
-            };
-            res.writeHead(this._H2.HTTP_STATUS_OK, headers);
-            stream.pipe(res);
-            return true;
-        } catch (e) {
-            this._logger.exception(e);
-            return false;
-        }
+                const stream = fs.createReadStream(fsPath);
+                const ext = path.extname(fsPath).toLowerCase();
+                const headers = {
+                    [H2.HTTP2_HEADER_CONTENT_LENGTH]: stat.size,
+                    [H2.HTTP2_HEADER_CONTENT_TYPE]: helpMime.getByExt(ext),
+                    [H2.HTTP2_HEADER_LAST_MODIFIED]: stat.mtime.toUTCString(),
+                };
+                res.writeHead(H2.HTTP_STATUS_OK, headers);
+                stream.pipe(res);
+                return true;
+            } catch (e) {
+                logger.exception(e);
+                return false;
+            }
+        };
     }
 }

--- a/src/Back/Handler/Static/A/Registry.js
+++ b/src/Back/Handler/Static/A/Registry.js
@@ -9,7 +9,6 @@ export default class Fl32_Web_Back_Handler_Static_A_Registry {
         }
     ) {
         /* eslint-enable jsdoc/check-param-names */
-        this._factory = configFactory;
         /** @type {ReturnType<Fl32_Web_Back_Handler_Static_A_Config['create']>[]} */
         let _configs = [];
 
@@ -20,7 +19,7 @@ export default class Fl32_Web_Back_Handler_Static_A_Registry {
          */
         this.setConfigs = function (dtoList = []) {
             _configs = dtoList
-                .map(dto => this._factory.create(dto))
+                .map(dto => configFactory.create(dto))
                 .sort((a, b) => b.prefix.length - a.prefix.length);
         };
 

--- a/src/Back/Handler/Static/A/Resolver.js
+++ b/src/Back/Handler/Static/A/Resolver.js
@@ -9,22 +9,20 @@ export default class Fl32_Web_Back_Handler_Static_A_Resolver {
         }
     ) {
         /* eslint-enable jsdoc/check-param-names */
-        this._path = path;
-    }
 
-    /**
-     * Resolve filesystem path for given config and relative URL part.
-     * Applies allow rules and security checks.
-     *
-     * @param {{root:string,prefix:string,allow?:Record<string,string[]>}} config
-     * @param {string} rel
-     * @returns {string|null} Absolute path or null when not allowed.
-     * @throws {Error} On path traversal attempts.
-     */
-    resolve(config, rel) {
-        if (rel.includes('..') || this._path.isAbsolute(rel)) {
-            throw new Error('Static access denied');
-        }
+        /**
+         * Resolve filesystem path for given config and relative URL part.
+         * Applies allow rules and security checks.
+         *
+         * @param {{root:string,prefix:string,allow?:Record<string,string[]>}} config
+         * @param {string} rel
+         * @returns {string|null} Absolute path or null when not allowed.
+         * @throws {Error} On path traversal attempts.
+         */
+        this.resolve = (config, rel) => {
+            if (rel.includes('..') || path.isAbsolute(rel)) {
+                throw new Error('Static access denied');
+            }
 
         if (config.allow) {
             let pkg; let subPath = '';
@@ -53,10 +51,11 @@ export default class Fl32_Web_Back_Handler_Static_A_Resolver {
             if (!allowed) return null;
         }
 
-        const fsPath = this._path.resolve(config.root, rel);
+        const fsPath = path.resolve(config.root, rel);
         if (!fsPath.startsWith(config.root)) {
             throw new Error('Resolved path is outside the root');
         }
         return fsPath;
+        };
     }
 }


### PR DESCRIPTION
## Summary
- use closure-based DI in Static handler and helpers
- adjust FileService, Fallback, Config, Resolver and Registry
- keep public APIs unchanged

## Testing
- `npm run test:unit`
- `npm run test:accept`
- `npm run eslint`


------
https://chatgpt.com/codex/tasks/task_e_685babf7e3bc832da2abab4bdbb8c6db