### PR TITLE
Fix static resolver default handling

### DIFF
--- a/src/Back/Handler/Static/A/Resolver.js
+++ b/src/Back/Handler/Static/A/Resolver.js
@@ -25,6 +25,17 @@ export default class Fl32_Web_Back_Handler_Static_A_Resolver {
             let pkgName;
             let subPath = '';
 
+            if (!config.allow) {
+                let fsPath = path.resolve(config.root, rel);
+                if (/[\\/]$/.test(fsPath) && fsPath.length > 1) {
+                    fsPath = fsPath.replace(/[\\/]+$/, '');
+                }
+                if (!fsPath.startsWith(config.root)) {
+                    throw new Error('Resolved path is outside the root');
+                }
+                return fsPath;
+            }
+
             // root‐level allow: '.' rules permit any rel under root
             if (config.allow?.['.'] != null) {
                 pkgName = '.';
@@ -58,7 +69,10 @@ export default class Fl32_Web_Back_Handler_Static_A_Resolver {
                 return null;
             }
 
-            const fsPath = path.resolve(config.root, rel);
+            let fsPath = path.resolve(config.root, rel);
+            if (/[\\/]$/.test(fsPath) && fsPath.length > 1) {
+                fsPath = fsPath.replace(/[\\/]+$/, '');
+            }
             if (!fsPath.startsWith(config.root)) {
                 throw new Error('Resolved path is outside the root');
             }


### PR DESCRIPTION
## Summary
- handle missing allow rules as open access
- strip trailing slashes in `Resolver` to resolve default index files

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_685bc37a71f0832daee4c5ac15f8747a