### PR TITLE
Add additive static registry

### DIFF
--- a/src/Back/Handler/Static.js
+++ b/src/Back/Handler/Static.js
@@ -37,7 +37,7 @@ export default class Fl32_Web_Back_Handler_Static {
          * @returns {Promise<void>}
          */
         this.init = async ({sources = []} = {}) => {
-            registry.setConfigs(sources);
+            registry.addConfigs(sources);
         };
 
         /**

--- a/src/Back/Handler/Static/A/Registry.js
+++ b/src/Back/Handler/Static/A/Registry.js
@@ -13,15 +13,21 @@ export default class Fl32_Web_Back_Handler_Static_A_Registry {
         let _configs = [];
 
         /**
-         * Store configuration list sorted by prefix length.
+         * Add configurations ensuring unique prefixes.
+         * Existing entries are not modified.
          *
          * @param {Fl32_Web_Back_Dto_Handler_Source.Dto[]} dtoList
          */
-        this.setConfigs = function (dtoList = []) {
-            _configs = dtoList
-                .map(dto => configFactory.create(dto))
-                .sort((a, b) => b.prefix.length - a.prefix.length);
+        this.addConfigs = function (dtoList = []) {
+            const list = dtoList.map(dto => configFactory.create(dto));
+            for (const cfg of list) {
+                if (!_configs.some(c => c.prefix === cfg.prefix)) {
+                    _configs.push(cfg);
+                }
+            }
+            _configs.sort((a, b) => b.prefix.length - a.prefix.length);
         };
+
 
         /**
          * Find configuration by matching URL prefix.

--- a/test/unit/Back/Handler/Static/A/Registry.test.mjs
+++ b/test/unit/Back/Handler/Static/A/Registry.test.mjs
@@ -1,27 +1,67 @@
-import {describe, it} from 'node:test';
+import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import {buildTestContainer} from '../../../../common.js';
+import { buildTestContainer } from '../../../../common.js';
+
+/** Simple config factory mock */
+function getMockFactory() {
+    return { create: dto => ({ root: dto.root, prefix: dto.prefix }) };
+}
 
 describe('Fl32_Web_Back_Handler_Static_A_Registry', () => {
-    it('sorts configurations by prefix length and finds matching config', async () => {
+    it('stores initial config', async () => {
         const container = buildTestContainer();
+        container.register('Fl32_Web_Back_Handler_Static_A_Config$', getMockFactory());
         /** @type {Fl32_Web_Back_Handler_Static_A_Registry} */
         const registry = await container.get('Fl32_Web_Back_Handler_Static_A_Registry$');
 
-        const dtos = [
-            {root: '/a', prefix: '/files/', defaults: []},
-            {root: '/b', prefix: '/files/special/', defaults: []}
-        ];
-        registry.setConfigs(dtos);
+        registry.addConfigs([{ root: '/a', prefix: '/p/' }]);
+        const match = registry.find('/p/file.txt');
 
-        const {resolve} = await import('node:path');
-        const match = registry.find('/files/special/test.txt');
+        assert.ok(match);
+        assert.strictEqual(match.config.root, '/a');
+    });
 
-        assert.ok(match, 'Expected a match for /files/special/test.txt');
-        assert.strictEqual(match.config.root, resolve('/b'));
-        assert.strictEqual(match.rel, 'test.txt');
+    it('adds config with new prefix', async () => {
+        const container = buildTestContainer();
+        container.register('Fl32_Web_Back_Handler_Static_A_Config$', getMockFactory());
+        const registry = await container.get('Fl32_Web_Back_Handler_Static_A_Registry$');
 
-        const noMatch = registry.find('/unknown');
-        assert.strictEqual(noMatch, null);
+        registry.addConfigs([{ root: '/a', prefix: '/p/' }]);
+        registry.addConfigs([{ root: '/b', prefix: '/p/s/' }]);
+
+        const match = registry.find('/p/s/file.txt');
+        assert.ok(match);
+        assert.strictEqual(match.config.root, '/b');
+    });
+
+    it('ignores config with existing prefix', async () => {
+        const container = buildTestContainer();
+        container.register('Fl32_Web_Back_Handler_Static_A_Config$', getMockFactory());
+        const registry = await container.get('Fl32_Web_Back_Handler_Static_A_Registry$');
+
+        registry.addConfigs([{ root: '/a', prefix: '/p/' }]);
+        registry.addConfigs([{ root: '/b', prefix: '/p/s/' }]);
+        registry.addConfigs([{ root: '/c', prefix: '/p/s/' }]);
+
+        const match = registry.find('/p/s/test.txt');
+        assert.ok(match);
+        assert.strictEqual(match.config.root, '/b');
+    });
+
+    it('prefers longer prefix when matching', async () => {
+        const container = buildTestContainer();
+        container.register('Fl32_Web_Back_Handler_Static_A_Config$', getMockFactory());
+        const registry = await container.get('Fl32_Web_Back_Handler_Static_A_Registry$');
+
+        registry.addConfigs([
+            { root: '/a', prefix: '/p/' },
+            { root: '/b', prefix: '/p/s/' }
+        ]);
+
+        const match1 = registry.find('/p/s/x.txt');
+        const match2 = registry.find('/p/y.txt');
+
+        assert.strictEqual(match1.config.root, '/b');
+        assert.strictEqual(match2.config.root, '/a');
     });
 });


### PR DESCRIPTION
## Summary
- make Static handler registry additive
- adjust Static handler to call new method
- test registry additive behavior
- remove backward compatibility alias

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_685cf6e31df8832d947249cd1390468b