### PR TITLE
Add unit test for Pre_Log handler

### DIFF
--- a/test/unit/Back/Handler/Pre/Log.test.mjs
+++ b/test/unit/Back/Handler/Pre/Log.test.mjs
@@ -1,0 +1,22 @@
+import {describe, it, beforeEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {buildTestContainer} from '../../../common.js';
+
+describe('Fl32_Web_Back_Handler_Pre_Log', () => {
+    let container;
+    const log = [];
+
+    beforeEach(() => {
+        log.length = 0;
+        container = buildTestContainer();
+        container.register('Fl32_Web_Back_Logger$', {
+            debug: (msg) => log.push(msg),
+        });
+    });
+
+    it('logs method and url', async () => {
+        const handler = await container.get('Fl32_Web_Back_Handler_Pre_Log$');
+        await handler.handle({method: 'GET', url: '/path'});
+        assert.deepStrictEqual(log, ['GET /path']);
+    });
+});


### PR DESCRIPTION
## Summary
- add new unit test for Pre_Log handler to verify logging behavior

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_685cfe6950ac832db5722e49a71b2d22