### PR TITLE
Add warning for duplicate static prefix

### DIFF
--- a/src/Back/Handler/Static/A/Registry.js
+++ b/src/Back/Handler/Static/A/Registry.js
@@ -2,10 +2,12 @@ export default class Fl32_Web_Back_Handler_Static_A_Registry {
     /* eslint-disable jsdoc/require-param-description,jsdoc/check-param-names */
     /**
      * @param {Fl32_Web_Back_Handler_Static_A_Config} configFactory
+     * @param {Fl32_Web_Back_Logger} logger
      */
     constructor(
         {
             Fl32_Web_Back_Handler_Static_A_Config$: configFactory,
+            Fl32_Web_Back_Logger$: logger,
         }
     ) {
         /* eslint-enable jsdoc/check-param-names */
@@ -23,6 +25,8 @@ export default class Fl32_Web_Back_Handler_Static_A_Registry {
             for (const cfg of list) {
                 if (!_configs.some(c => c.prefix === cfg.prefix)) {
                     _configs.push(cfg);
+                } else {
+                    logger.warn(`Static config with prefix ${cfg.prefix} already exists`);
                 }
             }
             _configs.sort((a, b) => b.prefix.length - a.prefix.length);

--- a/test/unit/Back/Handler/Static/A/Registry.test.mjs
+++ b/test/unit/Back/Handler/Static/A/Registry.test.mjs
@@ -48,6 +48,22 @@ describe('Fl32_Web_Back_Handler_Static_A_Registry', () => {
         assert.strictEqual(match.config.root, '/b');
     });
 
+    it('logs warning when prefix already exists', async () => {
+        const log = [];
+        const container = buildTestContainer();
+        container.register('Fl32_Web_Back_Handler_Static_A_Config$', getMockFactory());
+        container.register('Fl32_Web_Back_Logger$', {
+            warn: (...args) => log.push(args)
+        });
+        const registry = await container.get('Fl32_Web_Back_Handler_Static_A_Registry$');
+
+        registry.addConfigs([{ root: '/a', prefix: '/p/' }]);
+        registry.addConfigs([{ root: '/b', prefix: '/p/' }]);
+
+        assert.strictEqual(log.length, 1);
+        assert.ok(log[0][0].includes('/p/'));
+    });
+
     it('prefers longer prefix when matching', async () => {
         const container = buildTestContainer();
         container.register('Fl32_Web_Back_Handler_Static_A_Config$', getMockFactory());


### PR DESCRIPTION
## Summary
- warn if Static registry already has a prefix
- cover warning path in Registry tests

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_685cfe9de75c832dbff2f13f232b6a8a