### PR TITLE
Document node_modules static source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## [0.2.0] - 2025-06-21
 
 ### Added
-- Integration test covering NPM handler with the built-in server.
-- Built-in NPM handler for serving files from `node_modules`.
-- JSDoc examples for NPM handler initialization.
+- Integration test covering static file serving from `node_modules`.
+- Static handler can serve files from `node_modules` via `Handler_Source`.
+- JSDoc examples for initializing the static handler with a `Handler_Source` DTO.
 
 ## [0.1.0] - 2025-06-11
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ This example shows how to create a minimal application that:
 * Registers two handlers: a logger and a static file server
 * Starts a secure HTTPS server using built-in components
 
+The static handler reads from one or more **sources** described by the
+`Handler_Source` DTO. To expose selected files from `node_modules`, create a
+source with `root: 'node_modules'` and pass it to `Handler_Static` during
+initialization.
+
 ```js
 import Container from '@teqfw/di';
 import {readFileSync} from 'node:fs';


### PR DESCRIPTION
## Summary
- document using `Handler_Source` with `Handler_Static`
- reword CHANGELOG notes about the npm handler

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_685d09e1102c832d8fbca5ced9f11ba9