### PR TITLE
chore: release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.1] - 2025-08-21
+
+### Added
+- Added TeqFW descriptor to define package namespace for @teqfw/core.
+
 ## [0.3.0] - 2025-06-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flancer32/teq-web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flancer32/teq-web",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@teqfw/di": ">=0.34.0"
@@ -1829,7 +1829,7 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flancer32/teq-web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Node.js web plugin supporting Express and Fastify integration, with built-in server for standalone operation",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary
- add TeqFW descriptor entry and bump package version to 0.3.1

## Testing
- `npm run eslint` *(fails: Expected '!==' and instead saw '!=')*
- `npm run test:unit`
- `npm run test:accept`


------
https://chatgpt.com/codex/tasks/task_e_68a68ff974dc832d9c706eab1d6174be